### PR TITLE
load all necessary records when searching next

### DIFF
--- a/log-viewer-frontend/src/app/log-view/backend-events.ts
+++ b/log-viewer-frontend/src/app/log-view/backend-events.ts
@@ -92,6 +92,7 @@ export interface EventResponseAfterFilterChanged extends StatusHolderEvent {
 
 export interface EventSearchResponse extends StatusHolderEvent {
     records: Record[];
+    foundIdx: number;
     hasSkippedLine: boolean;
     requestId: number;
 }

--- a/log-viewer-frontend/src/app/log-view/log-view.component.ts
+++ b/log-viewer-frontend/src/app/log-view/log-view.component.ts
@@ -1298,9 +1298,8 @@ export class LogViewComponent implements OnInit, OnDestroy, AfterViewChecked, Ba
 
         SearchUtils.doSimpleSearch(data, this.searchPattern);
 
-        let nextOccurrenceIds = req.d > 0 ? data.length - 1 : 0;
-
-        SlUtils.assert(data[nextOccurrenceIds].searchRes.length > 0);
+        let nextOccurrenceIdx = event.foundIdx;
+        SlUtils.assert(data[nextOccurrenceIdx].searchRes.length > 0);
 
         if (!event.hasSkippedLine) {
             if (req.d < 0) {
@@ -1316,7 +1315,7 @@ export class LogViewComponent implements OnInit, OnDestroy, AfterViewChecked, Ba
                     return;
                 }
 
-                nextOccurrenceIds += this.m.length;
+                nextOccurrenceIdx += this.m.length;
                 this.addRecords(data);
 
                 this.hasRecordAfter = true;
@@ -1331,9 +1330,9 @@ export class LogViewComponent implements OnInit, OnDestroy, AfterViewChecked, Ba
 
         this.shiftView = 0;
 
-        this.setSelectedLine(nextOccurrenceIds);
+        this.setSelectedLine(nextOccurrenceIdx);
 
-        this.scrollToLine(nextOccurrenceIds);
+        this.scrollToLine(nextOccurrenceIdx);
     }
 
     @BackendEventHandler()

--- a/log-viewer/src/main/java/com/logviewer/web/dto/events/EventSearchResponse.java
+++ b/log-viewer/src/main/java/com/logviewer/web/dto/events/EventSearchResponse.java
@@ -1,24 +1,28 @@
 package com.logviewer.web.dto.events;
 
-import com.logviewer.web.dto.RestRecord;
-import com.logviewer.web.session.Status;
-import com.logviewer.web.session.tasks.SearchTask;
-
 import java.util.List;
-import java.util.Map;
+
+import com.logviewer.web.dto.RestRecord;
+import com.logviewer.web.session.tasks.SearchTask;
 
 public class EventSearchResponse extends StatusHolderEvent {
 
     public final List<RestRecord> records;
+    public final long foundIdx;
     public final boolean hasSkippedLine;
     public final long requestId;
 
-    public EventSearchResponse(Map<String, Status> statuses, long stateVersion, SearchTask.SearchResponse res, long requestId) {
-        super(statuses, stateVersion);
+    public EventSearchResponse(SearchTask.SearchResponse res, long stateVersion, long requestId, long foundIdx) {
+        super(res.getStatuses(), stateVersion);
 
         records = RestRecord.fromPairList(res.getData());
+        this.foundIdx = foundIdx;
         hasSkippedLine = res.hasSkippedLine();
         this.requestId = requestId;
+    }
+
+    public EventSearchResponse(SearchTask.SearchResponse res, long stateVersion, long requestId) {
+        this(res, stateVersion, requestId, -1);
     }
 
     @Override

--- a/log-viewer/src/test/java/com/logviewer/FailedLogTest.java
+++ b/log-viewer/src/test/java/com/logviewer/FailedLogTest.java
@@ -1,5 +1,13 @@
 package com.logviewer;
 
+import static com.logviewer.utils.TestSessionAdapter.*;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+
 import com.logviewer.data2.Position;
 import com.logviewer.web.dto.LogList;
 import com.logviewer.web.dto.events.EventNextDataLoaded;
@@ -7,14 +15,6 @@ import com.logviewer.web.dto.events.EventScrollToEdgeResponse;
 import com.logviewer.web.dto.events.EventSearchResponse;
 import com.logviewer.web.session.LogSession;
 import com.logviewer.web.session.tasks.SearchPattern;
-import org.junit.Test;
-import org.springframework.context.ApplicationContext;
-
-import java.util.Map;
-
-import static com.logviewer.utils.TestSessionAdapter.records;
-import static com.logviewer.utils.TestSessionAdapter.stateVersion;
-import static org.junit.Assert.*;
 
 public class FailedLogTest extends LogSessionTestBase {
 
@@ -33,15 +33,14 @@ public class FailedLogTest extends LogSessionTestBase {
         assertNull(resp.statuses.get("log.log").getError());
         assertNotNull(resp.statuses.get("unexisting-log.log").getError());
 
-        session.searchNext(new Position("zzz.log", TestUtils.date(0, 2), 0), false, 1, new SearchPattern("f"), hashes, 2, 1);
+        session.searchNext(new Position("zzz.log", TestUtils.date(0, 2), 0), false, 1, new SearchPattern("f"), hashes,
+            2, 1);
 
         adapter.check(EventSearchResponse.class, stateVersion(2), event -> {
             TestUtils.check(event.records, "150101 10:00:05 f");
             assert event.hasSkippedLine;
             assertEquals(1L, event.requestId);
         });
-
-        adapter.waitForType(EventNextDataLoaded.class);
 
         session.loadNext(new Position("zzz.log", TestUtils.date(0, 2), 0), false, 2, hashes, 2);
 

--- a/log-viewer/src/test/java/com/logviewer/LogSessionTest.java
+++ b/log-viewer/src/test/java/com/logviewer/LogSessionTest.java
@@ -162,9 +162,8 @@ public class LogSessionTest extends LogSessionTestBase {
 
         //
         session.searchNext(new Position("a.log", TestUtils.date(0, 1), 0), false, 3, new SearchPattern("xxx"), hashes, 2, 2);
-        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(2),
-                searchResult(false, "150101 10:00:01 zzz a", "150101 10:00:01 xxx b"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(2), searchResult(false, "150101 10:00:01 zzz a",
+            "150101 10:00:01 xxx b", "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a"));
 
         //
         TestPredicate.clear();
@@ -173,9 +172,8 @@ public class LogSessionTest extends LogSessionTestBase {
         TestPredicate.waitForRecord("150101 10:00:04 b");
         TestPredicate.unlock(lock);
 
-        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(3),
-                searchResult(true, "150101 10:00:03 a", "150101 10:00:04 b"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(3), searchResult(true, "150101 10:00:03 a",
+            "150101 10:00:04 b", "150101 10:00:05 a", "150101 10:00:06 a"));
 
         //
         lock = TestPredicate.lock("150101 10:00:04 b");
@@ -184,9 +182,8 @@ public class LogSessionTest extends LogSessionTestBase {
         TestPredicate.waitForRecord("150101 10:00:06 a");
         TestPredicate.unlock(lock);
 
-        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(4),
-                searchResult(true, "150101 10:00:03 a", "150101 10:00:04 b"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(4), searchResult(true, "150101 10:00:03 a",
+            "150101 10:00:04 b", "150101 10:00:05 a", "150101 10:00:06 a"));
 
         // Backward
         session.searchNext(new Position("z.log", TestUtils.date(0, 10), 0), true, 2, new SearchPattern("qssxcgr"), hashes, 2, 5);
@@ -194,21 +191,19 @@ public class LogSessionTest extends LogSessionTestBase {
 
         //
         session.searchNext(new Position("z.log", TestUtils.date(0, 10), 0), true, 2, new SearchPattern("xxx"), hashes, 2, 6);
-        adapter.check(EventSearchResponse.class, stateVersion(2),
-                searchResult(true, "150101 10:00:02 xxx a", "150101 10:00:03 a"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), searchResult(true, "150101 10:00:01 zzz a",
+            "150101 10:00:01 xxx b", "150101 10:00:02 xxx a", "150101 10:00:03 a"));
 
         //
         session.searchNext(new Position("z.log", TestUtils.date(0, 10), 0), true, 3, new SearchPattern("xxx"), hashes, 2, 6);
-        adapter.check(EventSearchResponse.class, stateVersion(2),
-                searchResult(true, "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), searchResult(true, "150101 10:00:01 zzz a",
+            "150101 10:00:01 xxx b", "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a"));
 
         //
         session.searchNext(new Position("z.log", TestUtils.date(0, 10), 0), true, 4, new SearchPattern("xxx"), hashes, 2, 7);
-        adapter.check(EventSearchResponse.class, stateVersion(2),
-                searchResult(true, "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a", "150101 10:00:04 b"));
-        adapter.waitForType(EventNextDataLoaded.class);
+        adapter.check(EventSearchResponse.class, stateVersion(2), searchResult(true, "150101 10:00:01 zzz a",
+            "150101 10:00:01 xxx b", "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a",
+            "150101 10:00:04 b"));
 
         //
         TestPredicate.clear();
@@ -217,8 +212,9 @@ public class LogSessionTest extends LogSessionTestBase {
         TestPredicate.waitForRecord("150101 10:00:01 zzz a");
         TestPredicate.unlock(lock);
 
-        adapter.check(EventSearchResponse.class, stateVersion(2),
-                searchResult(false, "150101 10:00:04 b", "150101 10:00:05 a", "150101 10:00:06 a"));
+        adapter.check(EventSearchResponse.class, stateVersion(2), searchResult(false, "150101 10:00:01 xxx b",
+            "150101 10:00:02 xxx a", "150101 10:00:03 a", "150101 10:00:03 a", "150101 10:00:04 b", "150101 10:00:05 a",
+            "150101 10:00:06 a"));
     }
 
     @Test
@@ -242,8 +238,8 @@ public class LogSessionTest extends LogSessionTestBase {
         TestPredicate.waitForRecord("150101 10:00:09 b");
         TestPredicate.unlock(lock);
 
-        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(2),
-                searchResult(true, "150101 10:00:06 a", "150101 10:00:06 ccc c"));
+        adapter.check(EventSearchResponse.class, stateVersion(2), reqId(2), searchResult(true, "150101 10:00:06 a",
+            "150101 10:00:06 ccc c", "150101 10:00:07 a", "150101 10:00:07 b"));
     }
 
     @Test


### PR DESCRIPTION
- loads next records (bacwkards or not) in the same search request and
sends back all data in the same search response;
- computes and sends back the found record index;
- avoids flickering in the frontend;